### PR TITLE
MARP-1333 Missing setup path for README_DE.md

### DIFF
--- a/skribble-connector-product/pom.xml
+++ b/skribble-connector-product/pom.xml
@@ -43,6 +43,8 @@
                 <copy file="README.md" tofile="${project.build.directory}/README.md" />
                 <loadfile property="variables.yaml" srcFile="${variables.yaml.file}" encoding="UTF-8" failonerror="false" />
                 <replace file="${project.build.directory}/README.md" token="@variables.yaml@" value="${variables.yaml}" />
+                <copy file="README_DE.md" tofile="${project.build.directory}/README_DE.md"/>
+                <replace file="${project.build.directory}/README_DE.md" token="@variables.yaml@" value="${variables.yaml}"/>
               </target>
             </configuration>
             <goals>

--- a/skribble-connector-product/zip.xml
+++ b/skribble-connector-product/zip.xml
@@ -20,6 +20,7 @@
       <outputDirectory>/</outputDirectory>
       <includes>
         <include>README.md</include>
+                <include>README_DE.md</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/skribble-connector-product/zip.xml
+++ b/skribble-connector-product/zip.xml
@@ -19,8 +19,7 @@
       <directory>target</directory>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>README.md</include>
-                <include>README_DE.md</include>
+        <include>README*.md</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Included README_DE.md in pom.xml and zip.xml